### PR TITLE
Don't cache failed requests

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -2,7 +2,7 @@ location /geocoding/v1/ {
     rewrite /geocoding/v1/(.*) /v1/$1  break;
     proxy_pass         http://pelias-api:8080/;
     proxy_cache        geocoding;
-    proxy_cache_valid  any  3d;
+    proxy_cache_valid  3d;
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
     proxy_redirect     off;
     proxy_set_header   Host $host;


### PR DESCRIPTION
Only responses with status codes 200, 301 and 302 are now cached. 