### PR TITLE
Next data cons

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -303,5 +303,6 @@ location /fonts/ {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
-    include           cors.conf;
+    add_header         'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    add_header         'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
 }

--- a/common.conf
+++ b/common.conf
@@ -241,14 +241,34 @@ location /routing-data/v2/finland {
     include            cors.conf;
 }
 
-location /routing-data/v2/next {
-    rewrite /routing-data/v2/next/(.*) /$1  break;
-    proxy_pass         http://opentripplanner-data-con-next:8080/;
+location /routing-data/v2/next-hsl {
+    rewrite /routing-data/v2/next-hsl/(.*) /$1  break;
+    proxy_pass         http://opentripplanner-data-con-next-hsl:8080/;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
-    add_header         Access-Control-Allow-Origin *;
+    include            cors.conf;
+}
+
+location /routing-data/v2/next-waltti {
+    rewrite /routing-data/v2/next-waltti/(.*) /$1  break;
+    proxy_pass         http://opentripplanner-data-con-next-waltti:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Host $host;
+    include            cors.conf;
+}
+
+location /routing-data/v2/next-finland {
+    rewrite /routing-data/v2/next-finland/(.*) /$1  break;
+    proxy_pass         http://opentripplanner-data-con-next-finland:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Host $host;
+    include            cors.conf;
 }
 
 location /ui/v1/finland/ {

--- a/test.js
+++ b/test.js
@@ -138,8 +138,12 @@ describe('api.digitransit.fi', function() {
   testResponseHeader('api.digitransit.fi','/routing-data/v2/waltti/router-config.json', 'access-control-allow-origin', '*');
   testProxying('api.digitransit.fi','/routing-data/v2/finland/router-finland.zip','opentripplanner-data-con-finland:8080');
   testResponseHeader('api.digitransit.fi','/routing-data/v2/finland/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('dev-api.digitransit.fi','/routing-data/v2/next/router-next.zip','opentripplanner-data-con-next:8080');
-  testResponseHeader('dev-api.digitransit.fi','/routing-data/v2/next/router-config.json', 'access-control-allow-origin', '*');
+  testProxying('dev-api.digitransit.fi','/routing-data/v2/next-hsl/router-hsl.zip','opentripplanner-data-con-next-hsl:8080');
+  testResponseHeader('dev-api.digitransit.fi','/routing-data/v2/next-hsl/router-config.json', 'access-control-allow-origin', '*');
+  testProxying('dev-api.digitransit.fi','/routing-data/v2/next-waltti/router-waltti.zip','opentripplanner-data-con-next-waltti:8080');
+  testResponseHeader('dev-api.digitransit.fi','/routing-data/v2/next-waltti/router-config.json', 'access-control-allow-origin', '*');
+  testProxying('dev-api.digitransit.fi','/routing-data/v2/next-finland/router-finland.zip','opentripplanner-data-con-next-finland:8080');
+  testResponseHeader('dev-api.digitransit.fi','/routing-data/v2/next-finland/router-config.json', 'access-control-allow-origin', '*');
   testProxying('api.digitransit.fi','/ui/v1/finland/sw.js','digitransit-ui-default:8080');
   testProxying('api.digitransit.fi','/ui/v1/waltti/sw.js','digitransit-ui-waltti:8080');
   testProxying('api.digitransit.fi','/ui/v1/hsl/sw.js','digitransit-ui-hsl:8080');


### PR DESCRIPTION
* Split opentripplanner-data-con-next into three different data containers
* Remove Access-Control-Allow-Origin header that is already being added at static.hsl.fi