### PR TITLE
Reittiopas redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 Requires docker + node
 
 ```bash
-./test.sh
+npm run test

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,7 +69,7 @@ http {
   }
 
   server {
-    server_name dev.reittiopas.fi beta.reittiopas.fi www.reittiopas.fi m.reittiopas.fi reittiopas.hsl.fi;
+    server_name dev.reittiopas.fi reittiopas.hsl.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {
@@ -86,14 +86,13 @@ http {
       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header   X-Forwarded-Host $host;
     }
+  }
 
-    location ~ ^/kaupunkipyorat/? {
-      rewrite /kaupunkipyorat/? https://beta.reittiopas.fi/?citybikes;
-    }
+  server {
+    server_name beta.reittiopas.fi www.reittiopas.fi m.reittiopas.fi;
+    listen 8080;
 
-    location ~ ^/kaupunkipyörät/? {
-      rewrite /kaupunkipyörät/? https://beta.reittiopas.fi/?citybikes;
-    }
+    return 301 https://reittiopas.hsl.fi$request_uri;
   }
 
   server {

--- a/test.js
+++ b/test.js
@@ -71,11 +71,12 @@ function testCaching(host, path, secure) {
   });
 }
 
-function testRedirect(host, path, expectedUrl) {
-  it('http request to ' + host + path + ' should redirect to ' + expectedUrl, function(done) {
-    get(host,path).end((err,res)=>{
-      expect(err.status).to.be.equal(301);
-      expect(err.response.header.location).to.be.equal(expectedUrl);
+function testRedirect(host, path, expectedUrl, secure=false) {
+  let fn = secure?httpsGet:get;
+  it('request to ' + host + path + ' should redirect to ' + expectedUrl, function(done) {
+    fn(host,path).end((err,res)=>{
+      expect(res).to.redirect;
+      expect(res).to.redirectTo(expectedUrl);
       done();
     });
   });
@@ -154,7 +155,9 @@ describe('api.digitransit.fi', function() {
 describe('hsl ui', function() {
   testRedirect('www.beta.reittiopas.fi','/kissa','http://beta.reittiopas.fi/kissa');
 
-  testRedirect('beta.reittiopas.fi','/kissa','https://beta.reittiopas.fi/kissa');
+  testRedirect('beta.reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa', true);
+  testRedirect('www.reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa', true);
+  testRedirect('m.reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa');
   testRedirect('dev.reittiopas.fi','/kissa','https://dev.reittiopas.fi/kissa');
 
   it('https should not redirect', function(done) {
@@ -164,7 +167,6 @@ describe('hsl ui', function() {
     });
   });
 
-  testProxying('beta.reittiopas.fi','/','digitransit-ui-hsl:8080', true);
   testProxying('dev.reittiopas.fi','/','digitransit-ui-hsl:8080', true);
 
   testProxying('reittiopas.hsl.fi','/','digitransit-ui-hsl:8080', true);


### PR DESCRIPTION
* Redirect reittiopas.fi and beta.reittiopas.fi to reittiopas.hsl.fi
* Allow redirect testing with https requests