### PR TITLE
Remove hslalert

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -44,26 +44,9 @@ location /realtime/trip-updates/v1/ {
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 }
 
-location /realtime/hslalert/v1/ {
-    rewrite /realtime/hslalert/v1/(.*) /$1  break;
-    proxy_pass         http://hslalert:8080/;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Host $host;
-    proxy_cache common;
-    proxy_cache_valid 200 30s;
-    proxy_cache_lock on;
-    proxy_cache_key "$host$request_uri";
-    add_header X-Proxy-Cache $upstream_cache_status;
-    proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-}
-
-#"alias" for hslalert
+# used to be "alias" for hslalert, now same as v2
 location /realtime/service-alerts/v1/ {
-    rewrite /realtime/service-alerts/v1/(.*) /$1  break;
-    proxy_pass         http://hslalert:8080/;
+    proxy_pass         https://transitdatadev.blob.core.windows.net/service-alerts/v2/hsl;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/common.conf
+++ b/common.conf
@@ -11,22 +11,6 @@ location /geocoding/v1/ {
     proxy_set_header   X-Forwarded-Host $host;
 }
 
-location /realtime/siri2gtfsrt/v1/ {
-    rewrite /realtime/siri2gtfsrt/v1/(.*) /$1  break;
-    proxy_pass         http://siri2gtfsrt:8080/;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Host $host;
-    proxy_cache common;
-    proxy_cache_valid 200 30s;
-    proxy_cache_lock on;
-    proxy_cache_key "$host$request_uri";
-    add_header X-Proxy-Cache $upstream_cache_status;
-    proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-}
-
 #"alias" for siri2gtfsrt
 location /realtime/trip-updates/v1/ {
     rewrite /realtime/siri2gtfsrt/v1/(.*) /$1  break;

--- a/common.conf
+++ b/common.conf
@@ -89,22 +89,6 @@ location /realtime/vehicle-positions/v2/hsl {
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 }
 
-location /realtime/navigator-server/v1/ {
-    rewrite /realtime/navigator-server/v1/(.*) /$1  break;
-    proxy_pass         http://navigator-server:8080/;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Host $host;
-    proxy_cache common;
-    proxy_cache_valid 200 30s;
-    proxy_cache_lock on;
-    proxy_cache_key "$host$request_uri";
-    add_header X-Proxy-Cache $upstream_cache_status;
-    proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-}
-
 #"alias" for navigator-server
 location /realtime/vehicle-positions/v1/ {
     rewrite /realtime/vehicle-positions/v1/(.*) /$1  break;

--- a/common.conf
+++ b/common.conf
@@ -106,23 +106,6 @@ location /realtime/vehicle-positions/v1/ {
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 }
 
-#"alias" for navigator-service
-location /realtime/mqtt-cache/v1/ {
-    rewrite /realtime/mqtt-cache/v1/(.*) /$1  break;
-    proxy_pass         http://navigator-server:8080/;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   X-Forwarded-Host $host;
-    proxy_cache common;
-    proxy_cache_valid 200 30s;
-    proxy_cache_lock on;
-    proxy_cache_key "$host$request_uri";
-    add_header X-Proxy-Cache $upstream_cache_status;
-    proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-}
-
 location /realtime/raildigitraffic2gtfsrt/v1/ {
     rewrite /realtime/raildigitraffic2gtfsrt/v1/(.*) /$1  break;
     proxy_pass         http://raildigitraffic2gtfsrt:8080;

--- a/test.js
+++ b/test.js
@@ -116,10 +116,6 @@ describe('api.digitransit.fi', function() {
   testCaching('api.digitransit.fi','/realtime/siri2gtfsrt/v1/foo', false)
   testProxying('api.digitransit.fi','/realtime/trip-updates/v1/','siri2gtfsrt:8080');
   testCaching('api.digitransit.fi','/realtime/trip-updates/v1/foo', false)
-  testProxying('api.digitransit.fi','/realtime/hslalert/v1/','hslalert:8080');
-  testCaching('api.digitransit.fi','/realtime/hslalert/v1/foo', false);
-  testProxying('api.digitransit.fi','/realtime/service-alerts/v1/','hslalert:8080');
-  testCaching('api.digitransit.fi','/realtime/service-alerts/v1/foo',false);
   testProxying('api.digitransit.fi','/realtime/navigator-server/v1/','navigator-server:8080');
   testCaching('api.digitransit.fi','/realtime/navigator-server/v1/foo',false);
   testProxying('api.digitransit.fi','/realtime/vehicle-positions/v1/','navigator-server:8080');

--- a/test.js
+++ b/test.js
@@ -116,8 +116,6 @@ describe('api.digitransit.fi', function() {
   testCaching('api.digitransit.fi','/realtime/trip-updates/v1/foo', false)
   testProxying('api.digitransit.fi','/realtime/vehicle-positions/v1/','navigator-server:8080');
   testCaching('api.digitransit.fi','/realtime/vehicle-positions/v1/foo',false);
-  testProxying('api.digitransit.fi','/realtime/mqtt-cache/v1/','navigator-server:8080');
-  testCaching('api.digitransit.fi','/realtime/mqtt-cache/v1/foo',false);
   testProxying('api.digitransit.fi','/realtime/raildigitraffic2gtfsrt/v1/','raildigitraffic2gtfsrt:8080');
   testCaching('api.digitransit.fi','/realtime/raildigitraffic2gtfsrt/v1/foo',true);
   testProxying('api.digitransit.fi','/map/v1/','hsl-map-server:8080');

--- a/test.js
+++ b/test.js
@@ -112,12 +112,8 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/geocoding/v1/','pelias-api:8080');
   testCaching('api.digitransit.fi','/geocoding/v1/foo', true);
   testProxying('api.digitransit.fi','/graphiql/hsl','graphiql:8080');
-  testProxying('api.digitransit.fi','/realtime/siri2gtfsrt/v1/','siri2gtfsrt:8080');
-  testCaching('api.digitransit.fi','/realtime/siri2gtfsrt/v1/foo', false)
   testProxying('api.digitransit.fi','/realtime/trip-updates/v1/','siri2gtfsrt:8080');
   testCaching('api.digitransit.fi','/realtime/trip-updates/v1/foo', false)
-  testProxying('api.digitransit.fi','/realtime/navigator-server/v1/','navigator-server:8080');
-  testCaching('api.digitransit.fi','/realtime/navigator-server/v1/foo',false);
   testProxying('api.digitransit.fi','/realtime/vehicle-positions/v1/','navigator-server:8080');
   testCaching('api.digitransit.fi','/realtime/vehicle-positions/v1/foo',false);
   testProxying('api.digitransit.fi','/realtime/mqtt-cache/v1/','navigator-server:8080');


### PR DESCRIPTION
* Remove all references to hslalert
* Remove following API endpoints that were not used at all or only by pingdom (changed pingdom to use alternative endpoints)
  - /realtime/siri2gtfsrt/v1/
  - /realtime/hslalert/v1/
  - /realtime/navigator-server/v1/
  - /realtime/mqtt-cache/v1/