### PR TITLE
Reconfigure timeouts

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -9,6 +9,7 @@ location /geocoding/v1/ {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 9s;
 }
 
 #"alias" for siri2gtfsrt
@@ -144,6 +145,7 @@ location /routing/v1/routers/finland {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 29500ms;
 }
 
 # Disable profile routing from Finland
@@ -158,6 +160,7 @@ location /routing/v1/routers/hsl {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
 }
 
 location /routing/v1/routers/waltti {
@@ -167,6 +170,7 @@ location /routing/v1/routers/waltti {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
 }
 
 # Disable profile routing from Waltti
@@ -181,6 +185,7 @@ location /routing/v1/routers/next-finland {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 29500ms;
 }
 
 location /routing/v1/routers/next-hsl {
@@ -190,6 +195,7 @@ location /routing/v1/routers/next-hsl {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
 }
 
 location /routing/v1/routers/next-waltti {
@@ -199,6 +205,7 @@ location /routing/v1/routers/next-waltti {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
 }
 
 location /routing-data/v2/hsl {

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,10 @@ http {
 
   sendfile on;
 
+  proxy_connect_timeout 10s;
+  proxy_send_timeout 10s;
+  proxy_read_timeout 10s;
+
   gzip              on;
   gzip_http_version 1.0;
   gzip_proxied      any;
@@ -50,9 +54,6 @@ http {
                   "";
 
     listen 8080;
-    proxy_connect_timeout 10s;
-    proxy_send_timeout 10s;
-    proxy_read_timeout 20s;
     include common.conf;
     include external.conf;
 


### PR DESCRIPTION
* Use custom timeouts in http block so it affects all servers/locations unless they are also defined in server or location level
* Reduce default read timeout
* Use custom timeouts for routing and geocoding queries