### PR TITLE
chore: New location for Matka.fi GTFS-RT source

### DIFF
--- a/external.conf
+++ b/external.conf
@@ -46,9 +46,9 @@ location /out/92.62.36.215/ {
   proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 }
 
-#new livi gtfs rt (https://beta.vayla.fi/joukkoliikenne/manual_gtfsrt/api/gtfsrt/alerts)
-location /out/beta.vayla.fi/ {
-  proxy_pass    https://beta.vayla.fi/;
+#new livi gtfs rt (https://tyokalu.navici.com/joukkoliikenne/manual-gtfsrt/api/gtfsrt/alerts)
+location /out/tyokalu.navici.com/ {
+  proxy_pass    https://tyokalu.navici.com/;
   include allowed-ips.conf;
   proxy_cache   ext_cache;
   proxy_cache_valid 200 30s;

--- a/test.js
+++ b/test.js
@@ -256,5 +256,5 @@ describe('ext-proxy', function() {
   testCaching('api.digitransit.fi','/out/data.foli.fi/citybike/smoove',false);
   testCaching('api.digitransit.fi','/out/p.hsl.fi/api/v1/facilities.json?limit=-1',false);
   testCaching('api.digitransit.fi','/out/92.62.36.215/RTIX/trip-updates',false);
-  testCaching('api.digitransit.fi','/out/beta.vayla.fi/joukkoliikenne/manual_gtfsrt/api/gtfsrt/alerts',false);
+  testCaching('api.digitransit.fi','/out/tyokalu.navici.com/joukkoliikenne/manual-gtfsrt/api/gtfsrt/alerts',false);
 });


### PR DESCRIPTION
beta.vayla.fi services are moving to tyokalu.navici.com