### PR TITLE
Prepare hsl ui configuration for new UI release

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -128,6 +128,9 @@ http {
       proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
       proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
     }
+    location = / {
+      return 301 https://dev.hslfi.hsldev.com/?fromJourneyPlanner=true;
+    }
     location / {
       return 301 https://reittiopas.hsl.fi$request_uri;
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -67,42 +67,7 @@ http {
   }
 
   server {
-    server_name dev.reittiopas.fi reittiopas.hsl.fi;
-    listen 8080;
-
-    if ($http_x_forwarded_proto != "https") {
-      return 301 https://$host$request_uri;
-    }
-
-    # Add HTTP Strict Transport Security for good measure.
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
-
-    location = /sw.js {
-      proxy_pass         http://digitransit-ui-hsl:8080;
-      proxy_redirect     off;
-      proxy_set_header   X-Real-IP $remote_addr;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Host $host;
-      proxy_cache sw;
-      proxy_cache_valid 200 30s;
-      proxy_cache_lock on;
-      proxy_cache_key "$host$request_uri";
-      add_header X-Proxy-Cache $upstream_cache_status;
-      proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-      proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    }
-
-    location / {
-      proxy_pass         http://digitransit-ui-hsl:8080;
-      proxy_redirect     off;
-      proxy_set_header   X-Real-IP $remote_addr;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Host $host;
-    }
-  }
-
-  server {
-    server_name vanha.reittiopas.hsl.fi;
+    server_name vanha.reittiopas.hsl.fi dev.reittiopas.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {
@@ -260,7 +225,7 @@ http {
   }
 
   server {
-    server_name next-dev.digitransit.fi uusi.reittiopas.hsl.fi;
+    server_name next-dev.digitransit.fi uusi.reittiopas.hsl.fi reittiopas.hsl.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {

--- a/test.js
+++ b/test.js
@@ -147,6 +147,7 @@ describe('api.digitransit.fi', function() {
 
 describe('hsl ui', function() {
   testRedirect('reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa');
+  testRedirect('reittiopas.fi','/','https://uusi.hsl.fi/?fromJourneyPlanner=true');
   testRedirect('www.reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa', true);
   testRedirect('m.reittiopas.fi','/kissa','https://reittiopas.hsl.fi/kissa');
   testRedirect('dev.reittiopas.fi','/kissa','https://dev.reittiopas.fi/kissa');

--- a/test.js
+++ b/test.js
@@ -159,8 +159,10 @@ describe('hsl ui', function() {
   });
 
   testProxying('dev.reittiopas.fi','/','digitransit-ui-hsl:8080', true);
+  testResponseHeader('dev.reittiopas.fi','/kissa', 'x-robots-tag', 'noindex, nofollow, nosnippet, noarchive');
 
-  testProxying('reittiopas.hsl.fi','/','digitransit-ui-hsl:8080', true);
+  testRedirect('reittiopas.hsl.fi','/','https://uusi.hsl.fi/?fromJourneyPlanner=true', true);
+  testProxying('reittiopas.hsl.fi','/kissa','digitransit-ui-hsl-next:8080', true);
 
   testCaching('reittiopas.hsl.fi','/sw.js', true);
 


### PR DESCRIPTION
* Use reittiopas.hsl.fi in the same fashion as uusi.reittiopas.hsl.fi
* Use dev.reittiopas.fi in the same fashion as vanha.reittiopas.hsl.fi
* Create root path redirect from www.reittiopas.fi and reittiopas.fi to new hsl.fi URL