### PR TITLE
Use new UI for a few waltti cities

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -183,15 +183,10 @@ http {
   server {
     server_name dev-hameenlinna.digitransit.fi hameenlinna.digitransit.fi reittiopas.hameenlinna.fi
                 dev-joensuu.digitransit.fi joensuu.digitransit.fi
-                dev-jyvaskyla.digitransit.fi jyvaskyla.digitransit.fi
                 dev-kotka.digitransit.fi kotka.digitransit.fi
-                dev-kuopio.digitransit.fi kuopio.digitransit.fi
                 dev-lahti.digitransit.fi lahti.digitransit.fi
                 dev-lappeenranta.digitransit.fi lappeenranta.digitransit.fi
-                dev-mikkeli.digitransit.fi mikkeli.digitransit.fi
                 dev-oulu.digitransit.fi oulu.digitransit.fi
-                dev-turku.digitransit.fi turku.digitransit.fi reittiopas.foli.fi
-                dev-tampere.digitransit.fi tampere.digitransit.fi pilottirepa.tampere.fi repa.tampere.fi reittiopas.tampere.fi
                 dev-kouvola.digitransit.fi kouvola.digitransit.fi
                 dev-rovaniemi.digitransit.fi rovaniemi.digitransit.fi
                 dev-opas.waltti.fi opas.waltti.fi;
@@ -266,15 +261,15 @@ http {
   server {
     server_name next-dev-hameenlinna.digitransit.fi
                 next-dev-joensuu.digitransit.fi
-                next-dev-jyvaskyla.digitransit.fi
+                next-dev-jyvaskyla.digitransit.fi dev-jyvaskyla.digitransit.fi jyvaskyla.digitransit.fi
                 next-dev-kotka.digitransit.fi
-                next-dev-kuopio.digitransit.fi
+                next-dev-kuopio.digitransit.fi dev-kuopio.digitransit.fi kuopio.digitransit.fi
                 next-dev-lahti.digitransit.fi
                 next-dev-lappeenranta.digitransit.fi
-                next-dev-mikkeli.digitransit.fi
+                next-dev-mikkeli.digitransit.fi dev-mikkeli.digitransit.fi mikkeli.digitransit.fi
                 next-dev-oulu.digitransit.fi
-                next-dev-turku.digitransit.fi
-                next-dev-tampere.digitransit.fi
+                next-dev-turku.digitransit.fi dev-turku.digitransit.fi turku.digitransit.fi reittiopas.foli.fi
+                next-dev-tampere.digitransit.fi dev-tampere.digitransit.fi tampere.digitransit.fi repa.tampere.fi reittiopas.tampere.fi
                 next-dev-kouvola.digitransit.fi
                 next-dev-rovaniemi.digitransit.fi
                 next-dev-opas.waltti.fi;

--- a/test.js
+++ b/test.js
@@ -201,10 +201,12 @@ describe('matka ui', function() {
 });
 
 describe('waltti ui', function() {
-  const cities = ['hameenlinna', 'jyvaskyla', 'joensuu', 'kotka', 'kuopio', 'lahti',
-                  'lappeenranta', 'mikkeli', 'oulu', 'turku', 'tampere', 'kouvola', 'rovaniemi'];
+  const legacyUICities = ['hameenlinna', 'joensuu', 'kotka', 'lahti',
+                  'lappeenranta', 'oulu', 'kouvola', 'rovaniemi'];
 
-  cities.forEach(function(city) {
+  const newUICities = ['jyvaskyla', 'kuopio', 'mikkeli', 'turku', 'tampere'];
+
+  legacyUICities.forEach(function(city) {
     testRedirect('dev-'+city+'.digitransit.fi','/kissa','https://dev-'+city+'.digitransit.fi/kissa');
     testProxying('dev-'+city+'.digitransit.fi','/','digitransit-ui-waltti:8080', true);
     testRedirect('next-dev-'+city+'.digitransit.fi','/kissa','https://next-dev-'+city+'.digitransit.fi/kissa');
@@ -213,20 +215,26 @@ describe('waltti ui', function() {
     testProxying(city+'.digitransit.fi','/','digitransit-ui-waltti:8080', true);
   });
 
+  newUICities.forEach(function(city) {
+    testRedirect('dev-'+city+'.digitransit.fi','/kissa','https://dev-'+city+'.digitransit.fi/kissa');
+    testProxying('dev-'+city+'.digitransit.fi','/','digitransit-ui-waltti-next:8080', true);
+    testRedirect('next-dev-'+city+'.digitransit.fi','/kissa','https://next-dev-'+city+'.digitransit.fi/kissa');
+    testProxying('next-dev-'+city+'.digitransit.fi','/','digitransit-ui-waltti-next:8080', true);
+    testRedirect(city+'.digitransit.fi','/kissa','https://'+city+'.digitransit.fi/kissa');
+    testProxying(city+'.digitransit.fi','/','digitransit-ui-waltti-next:8080', true);
+  });
+
   testRedirect('reittiopas.foli.fi','/kissa','https://reittiopas.foli.fi/kissa');
-  testProxying('reittiopas.foli.fi','/','digitransit-ui-waltti:8080', true);
+  testProxying('reittiopas.foli.fi','/','digitransit-ui-waltti-next:8080', true);
 
   testRedirect('reittiopas.hameenlinna.fi','/kissa','https://reittiopas.hameenlinna.fi/kissa');
   testProxying('reittiopas.hameenlinna.fi','/','digitransit-ui-waltti:8080', true);
 
-  testRedirect('pilottirepa.tampere.fi','/kissa','https://pilottirepa.tampere.fi/kissa');
-  testProxying('pilottirepa.tampere.fi','/','digitransit-ui-waltti:8080', true);
-
   testRedirect('repa.tampere.fi','/kissa','https://repa.tampere.fi/kissa');
-  testProxying('repa.tampere.fi','/','digitransit-ui-waltti:8080', true);
+  testProxying('repa.tampere.fi','/','digitransit-ui-waltti-next:8080', true);
 
   testRedirect('reittiopas.tampere.fi','/kissa','https://reittiopas.tampere.fi/kissa');
-  testProxying('reittiopas.tampere.fi','/','digitransit-ui-waltti:8080', true);
+  testProxying('reittiopas.tampere.fi','/','digitransit-ui-waltti-next:8080', true);
   testCaching('reittiopas.tampere.fi','/sw.js', true);
 
   testRedirect('opas.waltti.fi','/kissa','https://opas.waltti.fi/kissa');


### PR DESCRIPTION
* Use next ui for Tampere, Turku, Mikkeli, Jyväskylä, Kuopio
* Remove unused pilottirepa.tampere.fi domain support