### PR TITLE
DT-5006 Retire vanha.reittiopas.hsl.fi

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -69,40 +69,10 @@ http {
   }
 
   server {
-    server_name vanha.reittiopas.hsl.fi dev.reittiopas.fi;
+    server_name vanha.reittiopas.hsl.fi;
     listen 8080;
 
-    if ($http_x_forwarded_proto != "https") {
-      return 301 https://$host$request_uri;
-    }
-
-    # Add HTTP Strict Transport Security for good measure.
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
-    # Prevent search engines from indexing the site
-    add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
-
-    location = /sw.js {
-      proxy_pass         http://digitransit-ui-hsl:8080;
-      proxy_redirect     off;
-      proxy_set_header   X-Real-IP $remote_addr;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Host $host;
-      proxy_cache sw;
-      proxy_cache_valid 200 30s;
-      proxy_cache_lock on;
-      proxy_cache_key "$host$request_uri";
-      add_header X-Proxy-Cache $upstream_cache_status;
-      proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-      proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    }
-
-    location / {
-      proxy_pass         http://digitransit-ui-hsl:8080;
-      proxy_redirect     off;
-      proxy_set_header   X-Real-IP $remote_addr;
-      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Host $host;
-    }
+    return 301 https://reittiopas.hsl.fi/etusivu;
   }
 
   server {
@@ -289,7 +259,7 @@ http {
   }
 
   server {
-    server_name next-dev.digitransit.fi reittiopas.hsl.fi;
+    server_name dev.reittiopas.fi next-dev.digitransit.fi reittiopas.hsl.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {

--- a/test.js
+++ b/test.js
@@ -161,16 +161,14 @@ describe('hsl ui', function() {
     });
   });
 
-  testProxying('dev.reittiopas.fi','/','digitransit-ui-hsl:8080', true);
-  testResponseHeader('dev.reittiopas.fi','/kissa', 'x-robots-tag', 'noindex, nofollow, nosnippet, noarchive');
+  testProxying('dev.reittiopas.fi','/etusivu','digitransit-ui-hsl-next:8080', true);
 
   testRedirect('reittiopas.hsl.fi','/','https://uusi.hsl.fi/?fromJourneyPlanner=true', true);
   testProxying('reittiopas.hsl.fi','/kissa','digitransit-ui-hsl-next:8080', true);
 
   testCaching('reittiopas.hsl.fi','/sw.js', true);
 
-  testProxying('vanha.reittiopas.hsl.fi','/','digitransit-ui-hsl:8080', true);
-  testResponseHeader('vanha.reittiopas.hsl.fi','/kissa', 'x-robots-tag', 'noindex, nofollow, nosnippet, noarchive');
+  testRedirect('vanha.reittiopas.hsl.fi','/','https://reittiopas.hsl.fi/etusivu');
 
   //next-dev site
   testRedirect('www.next-dev.digitransit.fi','/kissa','http://next-dev.digitransit.fi/kissa');


### PR DESCRIPTION
* Use dev.reittiopas.fi as an alternative for next-dev.digitransit.fi
* Redirect from vanha.reittiopas.hsl.fi to reittiopas.hsl.fi/etusivu