### PR TITLE
Add hsl test service routing for browser assets

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -415,6 +415,15 @@ location /ui/v2/hsl/ {
     # proxy_set_header   X-Forwarded-Host $host;
 }
 
+location /ui/v2-test/hsl/ {
+    rewrite /ui/v2/hsl/(.*) /$1  break;
+    proxy_pass         http://digitransit-ui-hsl-v2-test:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    # proxy_set_header   X-Forwarded-Host $host;
+}
+
 location /ui/v2/waltti/ {
     rewrite /ui/v2/waltti/(.*) /$1  break;
     proxy_pass         http://digitransit-ui-waltti-v2:8080;


### PR DESCRIPTION
Blocks: https://github.com/HSLdevcom/digitransit-kubernetes-deploy/pull/100

Related issue: DT-4193
