### PR TITLE
Use v3 ui for opas.waltti.fi and varely

### DIFF
--- a/.github/workflows/prod-pipeline.yml
+++ b/.github/workflows/prod-pipeline.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check Tag
         id: check-tag
         run: |
-          if [[ ${GITHUB_REF##*/} =~ ^202[0-9][0-1][0-9][0-3][0-9]$ ]]; then
+          if [[ ${GITHUB_REF##*/} =~ ^202[0-9][0-1][0-9][0-3][0-9] ]]; then
               echo ::set-output name=match::true
           fi
       - name: Push latest image as prod

--- a/nginx.conf
+++ b/nginx.conf
@@ -214,9 +214,7 @@ http {
                 dev-tampere.digitransit.fi tampere.digitransit.fi repa.tampere.fi reittiopas.tampere.fi
                 dev-kouvola.digitransit.fi kouvola.digitransit.fi
                 dev-rovaniemi.digitransit.fi rovaniemi.digitransit.fi
-                dev-opas.waltti.fi opas.waltti.fi
-                dev-vaasa.digitransit.fi vaasa.digitransit.fi
-                dev-varely.digitransit.fi varely.digitransit.fi; 
+                dev-vaasa.digitransit.fi vaasa.digitransit.fi;
 
     listen 8080;
 
@@ -269,8 +267,9 @@ http {
                 next-dev-tampere.digitransit.fi
                 next-dev-kouvola.digitransit.fi
                 next-dev-rovaniemi.digitransit.fi
-                next-dev-opas.waltti.fi
-                next-dev-vaasa.digitransit.fi;
+                next-dev-opas.waltti.fi dev-opas.waltti.fi opas.waltti.fi
+                next-dev-vaasa.digitransit.fi
+                dev-varely.digitransit.fi varely.digitransit.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {

--- a/test.js
+++ b/test.js
@@ -228,7 +228,7 @@ describe('waltti ui', function() {
   testCaching('reittiopas.tampere.fi','/sw.js', true);
 
   testRedirect('opas.waltti.fi','/kissa','https://opas.waltti.fi/kissa');
-  testProxying('opas.waltti.fi','/','digitransit-ui-waltti-v2:8080', true);
+  testProxying('opas.waltti.fi','/','digitransit-ui-waltti-v3:8080', true);
 
   testRedirect('opas.waltti.fi','/haku','https://opas.waltti.fi/haku');
   testResponseHeader('opas.waltti.fi','/haku', 'X-Frame-Options', undefined);


### PR DESCRIPTION
* Moves opas.waltti.fi and varely to use v3 version of ui instead of v2
* Modifies release tag check so it allows postfixes