### PR TITLE
Add v3 map API

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -158,6 +158,220 @@ location /map/v2/ {
     add_header         X-Cache-Status $upstream_cache_status;
 }
 
+location /map/v3/ {
+    rewrite /map/v3/(.*) /map/v2/$1  break;
+    proxy_pass         http://hsl-map-server:8080;
+    proxy_cache        tiles;
+    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+    proxy_cache_revalidate on;
+    proxy_cache_lock   on;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    # proxy_set_header   X-Forwarded-Host $host;
+    add_header         X-Cache-Status $upstream_cache_status;
+}
+
+location /map/v3/poi/hsl-ticket-sales-map/ {
+    rewrite /map/v3/poi/(.*) /map/v2/$1  break;
+    proxy_pass         http://hsl-map-server:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-stops/ {
+    rewrite /map/v3/poi/hsl-stops/(.*) /otp/routers/hsl/vectorTiles/stops/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-stations/ {
+    rewrite /map/v3/poi/hsl-stations/(.*) /otp/routers/hsl/vectorTiles/stations/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-rental-stations/ {
+    rewrite /map/v3/poi/hsl-rental-stations/(.*) /otp/routers/hsl/vectorTiles/rentalStations/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-realtime-rental-stations/ {
+    rewrite /map/v3/poi/hsl-realtime-rental-stations/(.*) /otp/routers/hsl/vectorTiles/realtimeRentalStations/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-vehicle-parking/ {
+    rewrite /map/v3/poi/hsl-vehicle-parking/(.*) /otp/routers/hsl/vectorTiles/vehicleParking/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/hsl-vehicle-parking-groups/ {
+    rewrite /map/v3/poi/hsl-vehicle-parking-groups/(.*) /otp/routers/hsl/vectorTiles/vehicleParkingGroups/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-stops/ {
+    rewrite /map/v3/poi/waltti-stops/(.*) /otp/routers/waltti/vectorTiles/stops/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-stations/ {
+    rewrite /map/v3/poi/waltti-stations/(.*) /otp/routers/waltti/vectorTiles/stations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-rental-stations/ {
+    rewrite /map/v3/poi/waltti-rental-stations/(.*) /otp/routers/waltti/vectorTiles/rentalStations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-realtime-rental-stations/ {
+    rewrite /map/v3/poi/waltti-realtime-rental-stations/(.*) /otp/routers/waltti/vectorTiles/realtimeRentalStations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-vehicle-parking/ {
+    rewrite /map/v3/poi/waltti-vehicle-parking/(.*) /otp/routers/waltti/vectorTiles/vehicleParking/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-vehicle-parking-groups/ {
+    rewrite /map/v3/poi/waltti-vehicle-parking-groups/(.*) /otp/routers/waltti/vectorTiles/vehicleParkingGroups/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-stops/ {
+    rewrite /map/v3/poi/finland-stops/(.*) /otp/routers/finland/vectorTiles/stops/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-stations/ {
+    rewrite /map/v3/poi/finland-stations/(.*) /otp/routers/finland/vectorTiles/stations/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-rental-stations/ {
+    rewrite /map/v3/poi/finland-rental-stations/(.*) /otp/routers/finland/vectorTiles/rentalStations/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-realtime-rental-stations/ {
+    rewrite /map/v3/poi/finland-realtime-rental-stations/(.*) /otp/routers/finland/vectorTiles/realtimeRentalStations/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-vehicle-parking/ {
+    rewrite /map/v3/poi/finland-vehicle-parking/(.*) /otp/routers/finland/vectorTiles/vehicleParking/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/finland-vehicle-parking-groups/ {
+    rewrite /map/v3/poi/finland-vehicle-parking-groups/(.*) /otp/routers/finland/vectorTiles/vehicleParkingGroups/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-alt-stops/ {
+    rewrite /map/v3/poi/waltti-alt-stops/(.*) /otp/routers/waltti-alt/vectorTiles/stops/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-alt-stations/ {
+    rewrite /map/v3/poi/waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/stations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-alt-rental-stations/ {
+    rewrite /map/v3/poi/finland-waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/rentalStations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/waltti-alt-realtime-rental-stations/ {
+    rewrite /map/v3/poi/waltti-alt-realtime-rental-stations/(.*) /otp/routers/waltti-alt/vectorTiles/realtimeRentalStations/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/varely-stops/ {
+    rewrite /map/v3/poi/varely-stops/(.*) /otp/routers/varely/vectorTiles/stops/$1  break;
+    proxy_pass         http://opentripplanner-varely-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/poi/varely-stations/ {
+    rewrite /map/v3/poi/varely-stations/(.*) /otp/routers/varely/vectorTiles/stations/$1  break;
+    proxy_pass         http://opentripplanner-varely-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
 location /graphiql/ {
   proxy_pass         http://graphiql:8080;
   proxy_redirect     off;

--- a/common.conf
+++ b/common.conf
@@ -172,200 +172,200 @@ location /map/v3/ {
     add_header         X-Cache-Status $upstream_cache_status;
 }
 
-location /map/v3/poi/hsl-ticket-sales-map/ {
-    rewrite /map/v3/poi/(.*) /map/v2/$1  break;
+location /map/v3/hsl-ticket-sales-map/ {
+    rewrite /map/v3/(.*) /map/v2/$1  break;
     proxy_pass         http://hsl-map-server:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-stops/ {
-    rewrite /map/v3/poi/hsl-stops/(.*) /otp/routers/hsl/vectorTiles/stops/$1  break;
+location /map/v3/hsl-stops/ {
+    rewrite /map/v3/hsl-stops/(.*) /otp/routers/hsl/vectorTiles/stops/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-stations/ {
-    rewrite /map/v3/poi/hsl-stations/(.*) /otp/routers/hsl/vectorTiles/stations/$1  break;
+location /map/v3/hsl-stations/ {
+    rewrite /map/v3/hsl-stations/(.*) /otp/routers/hsl/vectorTiles/stations/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-rental-stations/ {
-    rewrite /map/v3/poi/hsl-rental-stations/(.*) /otp/routers/hsl/vectorTiles/rentalStations/$1  break;
+location /map/v3/hsl-rental-stations/ {
+    rewrite /map/v3/hsl-rental-stations/(.*) /otp/routers/hsl/vectorTiles/rentalStations/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-realtime-rental-stations/ {
-    rewrite /map/v3/poi/hsl-realtime-rental-stations/(.*) /otp/routers/hsl/vectorTiles/realtimeRentalStations/$1  break;
+location /map/v3/hsl-realtime-rental-stations/ {
+    rewrite /map/v3/hsl-realtime-rental-stations/(.*) /otp/routers/hsl/vectorTiles/realtimeRentalStations/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-vehicle-parking/ {
-    rewrite /map/v3/poi/hsl-vehicle-parking/(.*) /otp/routers/hsl/vectorTiles/vehicleParking/$1  break;
+location /map/v3/hsl-vehicle-parking/ {
+    rewrite /map/v3/hsl-vehicle-parking/(.*) /otp/routers/hsl/vectorTiles/vehicleParking/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/hsl-vehicle-parking-groups/ {
-    rewrite /map/v3/poi/hsl-vehicle-parking-groups/(.*) /otp/routers/hsl/vectorTiles/vehicleParkingGroups/$1  break;
+location /map/v3/hsl-vehicle-parking-groups/ {
+    rewrite /map/v3/hsl-vehicle-parking-groups/(.*) /otp/routers/hsl/vectorTiles/vehicleParkingGroups/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-stops/ {
-    rewrite /map/v3/poi/waltti-stops/(.*) /otp/routers/waltti/vectorTiles/stops/$1  break;
+location /map/v3/waltti-stops/ {
+    rewrite /map/v3/waltti-stops/(.*) /otp/routers/waltti/vectorTiles/stops/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-stations/ {
-    rewrite /map/v3/poi/waltti-stations/(.*) /otp/routers/waltti/vectorTiles/stations/$1  break;
+location /map/v3/waltti-stations/ {
+    rewrite /map/v3/waltti-stations/(.*) /otp/routers/waltti/vectorTiles/stations/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-rental-stations/ {
-    rewrite /map/v3/poi/waltti-rental-stations/(.*) /otp/routers/waltti/vectorTiles/rentalStations/$1  break;
+location /map/v3/waltti-rental-stations/ {
+    rewrite /map/v3/waltti-rental-stations/(.*) /otp/routers/waltti/vectorTiles/rentalStations/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-realtime-rental-stations/ {
-    rewrite /map/v3/poi/waltti-realtime-rental-stations/(.*) /otp/routers/waltti/vectorTiles/realtimeRentalStations/$1  break;
+location /map/v3/waltti-realtime-rental-stations/ {
+    rewrite /map/v3/waltti-realtime-rental-stations/(.*) /otp/routers/waltti/vectorTiles/realtimeRentalStations/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-vehicle-parking/ {
-    rewrite /map/v3/poi/waltti-vehicle-parking/(.*) /otp/routers/waltti/vectorTiles/vehicleParking/$1  break;
+location /map/v3/waltti-vehicle-parking/ {
+    rewrite /map/v3/waltti-vehicle-parking/(.*) /otp/routers/waltti/vectorTiles/vehicleParking/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-vehicle-parking-groups/ {
-    rewrite /map/v3/poi/waltti-vehicle-parking-groups/(.*) /otp/routers/waltti/vectorTiles/vehicleParkingGroups/$1  break;
+location /map/v3/waltti-vehicle-parking-groups/ {
+    rewrite /map/v3/waltti-vehicle-parking-groups/(.*) /otp/routers/waltti/vectorTiles/vehicleParkingGroups/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-stops/ {
-    rewrite /map/v3/poi/finland-stops/(.*) /otp/routers/finland/vectorTiles/stops/$1  break;
+location /map/v3/finland-stops/ {
+    rewrite /map/v3/finland-stops/(.*) /otp/routers/finland/vectorTiles/stops/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-stations/ {
-    rewrite /map/v3/poi/finland-stations/(.*) /otp/routers/finland/vectorTiles/stations/$1  break;
+location /map/v3/finland-stations/ {
+    rewrite /map/v3/finland-stations/(.*) /otp/routers/finland/vectorTiles/stations/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-rental-stations/ {
-    rewrite /map/v3/poi/finland-rental-stations/(.*) /otp/routers/finland/vectorTiles/rentalStations/$1  break;
+location /map/v3/finland-rental-stations/ {
+    rewrite /map/v3/finland-rental-stations/(.*) /otp/routers/finland/vectorTiles/rentalStations/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-realtime-rental-stations/ {
-    rewrite /map/v3/poi/finland-realtime-rental-stations/(.*) /otp/routers/finland/vectorTiles/realtimeRentalStations/$1  break;
+location /map/v3/finland-realtime-rental-stations/ {
+    rewrite /map/v3/finland-realtime-rental-stations/(.*) /otp/routers/finland/vectorTiles/realtimeRentalStations/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-vehicle-parking/ {
-    rewrite /map/v3/poi/finland-vehicle-parking/(.*) /otp/routers/finland/vectorTiles/vehicleParking/$1  break;
+location /map/v3/finland-vehicle-parking/ {
+    rewrite /map/v3/finland-vehicle-parking/(.*) /otp/routers/finland/vectorTiles/vehicleParking/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/finland-vehicle-parking-groups/ {
-    rewrite /map/v3/poi/finland-vehicle-parking-groups/(.*) /otp/routers/finland/vectorTiles/vehicleParkingGroups/$1  break;
+location /map/v3/finland-vehicle-parking-groups/ {
+    rewrite /map/v3/finland-vehicle-parking-groups/(.*) /otp/routers/finland/vectorTiles/vehicleParkingGroups/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-alt-stops/ {
-    rewrite /map/v3/poi/waltti-alt-stops/(.*) /otp/routers/waltti-alt/vectorTiles/stops/$1  break;
+location /map/v3/waltti-alt-stops/ {
+    rewrite /map/v3/waltti-alt-stops/(.*) /otp/routers/waltti-alt/vectorTiles/stops/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-alt-stations/ {
-    rewrite /map/v3/poi/waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/stations/$1  break;
+location /map/v3/waltti-alt-stations/ {
+    rewrite /map/v3/waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/stations/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-alt-rental-stations/ {
-    rewrite /map/v3/poi/finland-waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/rentalStations/$1  break;
+location /map/v3/waltti-alt-rental-stations/ {
+    rewrite /map/v3/finland-waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/rentalStations/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/waltti-alt-realtime-rental-stations/ {
-    rewrite /map/v3/poi/waltti-alt-realtime-rental-stations/(.*) /otp/routers/waltti-alt/vectorTiles/realtimeRentalStations/$1  break;
+location /map/v3/waltti-alt-realtime-rental-stations/ {
+    rewrite /map/v3/waltti-alt-realtime-rental-stations/(.*) /otp/routers/waltti-alt/vectorTiles/realtimeRentalStations/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/varely-stops/ {
-    rewrite /map/v3/poi/varely-stops/(.*) /otp/routers/varely/vectorTiles/stops/$1  break;
+location /map/v3/varely-stops/ {
+    rewrite /map/v3/varely-stops/(.*) /otp/routers/varely/vectorTiles/stops/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/poi/varely-stations/ {
-    rewrite /map/v3/poi/varely-stations/(.*) /otp/routers/varely/vectorTiles/stations/$1  break;
+location /map/v3/varely-stations/ {
+    rewrite /map/v3/varely-stations/(.*) /otp/routers/varely/vectorTiles/stations/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;

--- a/common.conf
+++ b/common.conf
@@ -172,200 +172,48 @@ location /map/v3/ {
     add_header         X-Cache-Status $upstream_cache_status;
 }
 
-location /map/v3/hsl-ticket-sales-map/ {
-    rewrite /map/v3/(.*) /map/v2/$1  break;
+location /map/v3/hsl/ {
+    rewrite /map/v3/hsl/(.*) /otp/routers/hsl/vectorTiles/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /map/v3/hsl/ticket-sales-map/ {
+    rewrite /map/v3/hsl/ticket-sales-map/(.*) /map/v2/hsl-ticket-sales-map/$1  break;
     proxy_pass         http://hsl-map-server:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/hsl-stops/ {
-    rewrite /map/v3/hsl-stops/(.*) /otp/routers/hsl/vectorTiles/stops/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/hsl-stations/ {
-    rewrite /map/v3/hsl-stations/(.*) /otp/routers/hsl/vectorTiles/stations/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/hsl-rental-stations/ {
-    rewrite /map/v3/hsl-rental-stations/(.*) /otp/routers/hsl/vectorTiles/rentalStations/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/hsl-realtime-rental-stations/ {
-    rewrite /map/v3/hsl-realtime-rental-stations/(.*) /otp/routers/hsl/vectorTiles/realtimeRentalStations/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/hsl-vehicle-parking/ {
-    rewrite /map/v3/hsl-vehicle-parking/(.*) /otp/routers/hsl/vectorTiles/vehicleParking/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/hsl-vehicle-parking-groups/ {
-    rewrite /map/v3/hsl-vehicle-parking-groups/(.*) /otp/routers/hsl/vectorTiles/vehicleParkingGroups/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-stops/ {
-    rewrite /map/v3/waltti-stops/(.*) /otp/routers/waltti/vectorTiles/stops/$1  break;
+location /map/v3/waltti/ {
+    rewrite /map/v3/waltti/(.*) /otp/routers/waltti/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/waltti-stations/ {
-    rewrite /map/v3/waltti-stations/(.*) /otp/routers/waltti/vectorTiles/stations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-rental-stations/ {
-    rewrite /map/v3/waltti-rental-stations/(.*) /otp/routers/waltti/vectorTiles/rentalStations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-realtime-rental-stations/ {
-    rewrite /map/v3/waltti-realtime-rental-stations/(.*) /otp/routers/waltti/vectorTiles/realtimeRentalStations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-vehicle-parking/ {
-    rewrite /map/v3/waltti-vehicle-parking/(.*) /otp/routers/waltti/vectorTiles/vehicleParking/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-vehicle-parking-groups/ {
-    rewrite /map/v3/waltti-vehicle-parking-groups/(.*) /otp/routers/waltti/vectorTiles/vehicleParkingGroups/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/finland-stops/ {
-    rewrite /map/v3/finland-stops/(.*) /otp/routers/finland/vectorTiles/stops/$1  break;
+location /map/v3/finland/ {
+    rewrite /map/v3/finland/(.*) /otp/routers/finland/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/finland-stations/ {
-    rewrite /map/v3/finland-stations/(.*) /otp/routers/finland/vectorTiles/stations/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/finland-rental-stations/ {
-    rewrite /map/v3/finland-rental-stations/(.*) /otp/routers/finland/vectorTiles/rentalStations/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/finland-realtime-rental-stations/ {
-    rewrite /map/v3/finland-realtime-rental-stations/(.*) /otp/routers/finland/vectorTiles/realtimeRentalStations/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/finland-vehicle-parking/ {
-    rewrite /map/v3/finland-vehicle-parking/(.*) /otp/routers/finland/vectorTiles/vehicleParking/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/finland-vehicle-parking-groups/ {
-    rewrite /map/v3/finland-vehicle-parking-groups/(.*) /otp/routers/finland/vectorTiles/vehicleParkingGroups/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-alt-stops/ {
-    rewrite /map/v3/waltti-alt-stops/(.*) /otp/routers/waltti-alt/vectorTiles/stops/$1  break;
+location /map/v3/waltti-alt/ {
+    rewrite /map/v3/waltti-alt/(.*) /otp/routers/waltti-alt/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /map/v3/waltti-alt-stations/ {
-    rewrite /map/v3/waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/stations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-alt-rental-stations/ {
-    rewrite /map/v3/finland-waltti-alt-stations/(.*) /otp/routers/waltti-alt/vectorTiles/rentalStations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/waltti-alt-realtime-rental-stations/ {
-    rewrite /map/v3/waltti-alt-realtime-rental-stations/(.*) /otp/routers/waltti-alt/vectorTiles/realtimeRentalStations/$1  break;
-    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/varely-stops/ {
-    rewrite /map/v3/varely-stops/(.*) /otp/routers/varely/vectorTiles/stops/$1  break;
-    proxy_pass         http://opentripplanner-varely-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location /map/v3/varely-stations/ {
-    rewrite /map/v3/varely-stations/(.*) /otp/routers/varely/vectorTiles/stations/$1  break;
+location /map/v3/varely/ {
+    rewrite /map/v3/varely/(.*) /otp/routers/varely/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;

--- a/test.js
+++ b/test.js
@@ -121,12 +121,12 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/map/v1/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v2/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/hsl-ticket-sales-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/hsl-rental-stations/','opentripplanner-hsl-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/waltti-rental-stations/','opentripplanner-waltti-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/finland-rental-stations/','opentripplanner-finland-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/varely-stops/','opentripplanner-varely-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/waltti-alt-rental-stations/','opentripplanner-waltti-alt-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl/ticket-sales-map/','hsl-map-server:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl/rental-stations/','opentripplanner-hsl-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/waltti/rental-stations/','opentripplanner-waltti-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/finland/rental-stations/','opentripplanner-finland-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/varely/stops,stations/','opentripplanner-varely-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/waltti-alt/rental-stations/','opentripplanner-waltti-alt-v2:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/finland','opentripplanner-finland:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/hsl','opentripplanner-hsl:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/waltti','opentripplanner-waltti:8080');

--- a/test.js
+++ b/test.js
@@ -120,6 +120,13 @@ describe('api.digitransit.fi', function() {
  //testCaching('api.digitransit.fi','/realtime/raildigitraffic2gtfsrt/v1/foo',true);
   testProxying('api.digitransit.fi','/map/v1/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v2/','hsl-map-server:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/hsl-ticket-sales-map/','hsl-map-server:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/hsl-rental-stations/','opentripplanner-hsl-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/waltti-rental-stations/','opentripplanner-waltti-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/finland-rental-stations/','opentripplanner-finland-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/varely-stops/','opentripplanner-varely-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/poi/waltti-alt-rental-stations/','opentripplanner-waltti-alt-v2:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/finland','opentripplanner-finland:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/hsl','opentripplanner-hsl:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/waltti','opentripplanner-waltti:8080');

--- a/test.js
+++ b/test.js
@@ -121,12 +121,12 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/map/v1/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v2/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/hsl-ticket-sales-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/hsl-rental-stations/','opentripplanner-hsl-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/waltti-rental-stations/','opentripplanner-waltti-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/finland-rental-stations/','opentripplanner-finland-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/varely-stops/','opentripplanner-varely-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/poi/waltti-alt-rental-stations/','opentripplanner-waltti-alt-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl-ticket-sales-map/','hsl-map-server:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl-rental-stations/','opentripplanner-hsl-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/waltti-rental-stations/','opentripplanner-waltti-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/finland-rental-stations/','opentripplanner-finland-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/varely-stops/','opentripplanner-varely-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/waltti-alt-rental-stations/','opentripplanner-waltti-alt-v2:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/finland','opentripplanner-finland:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/hsl','opentripplanner-hsl:8080');
   testProxying('api.digitransit.fi','/routing/v1/routers/waltti','opentripplanner-waltti:8080');


### PR DESCRIPTION
Adds experimental v3 map API. It only differs from v2 by exposing otp's map layers that can be used instead of the hsl-map-server's similar layers.