### PR TITLE
Remove api subscription key from geocoding cache DT-5607

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -3,6 +3,7 @@ location /geocoding/v1/ {
     proxy_pass         http://pelias-api:8080/;
     proxy_cache        geocoding;
     proxy_cache_valid  3d;
+    proxy_cache_key $geo_cache_key;
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
     add_header X-Proxy-Cache $upstream_cache_status;
     proxy_redirect     off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,11 @@ daemon off;
 
 http {
 
+  map $request_uri $geo_cache_key {
+    "~(?<location>geocoding\/v1\/(.*)\?)digitransit-subscription-key=((.*?)\&)(?<params>(.*))" $location$params;
+    default                    $request_uri;
+  }
+
   log_format custom '$remote_addr - $remote_user [$time_local] '
                       '"$request" $status $body_bytes_sent '
                       '"$http_user_agent" $host $request_time';

--- a/test.js
+++ b/test.js
@@ -110,7 +110,9 @@ describe('api.digitransit.fi', function() {
   });
 
   testProxying('api.digitransit.fi','/geocoding/v1/','pelias-api:8080');
-  //testCaching('api.digitransit.fi','/geocoding/v1/foo', true);
+  testCaching('api.digitransit.fi','/geocoding/v1/search?digitransit-subscription-key=1234567890&text=porin%20tori', true);
+  testCaching('api.digitransit.fi', '/geocoding/v1/reverse?digitransit-subscription-key=1234567890&point.lat=60.199284&point.lon=24.940540&size=1', true)
+  testCaching('api.digitransit.fi', '/geocoding/v1/autocomplete?digitransit-subscription-key=1234567890&text=kamp&layers=address', true)
   testProxying('api.digitransit.fi','/graphiql/hsl','graphiql:8080');
   testProxying('api.digitransit.fi','/realtime/trip-updates/v1/FOLI','siri2gtfsrt:8080');
   //testCaching('api.digitransit.fi','/realtime/trip-updates/v1/foo', false)


### PR DESCRIPTION
Default cache key was previously used ($scheme$proxy_host$request_uri). Specify cache key by mapping it from $request_uri and removing subscription key