### PR TITLE
Remove old kela routing and map endpoints

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -201,33 +201,6 @@ location /map/v3/varely/en/ {
     proxy_set_header   Accept-Language "en";
 }
 
-location /map/v3/kela/fi/ {
-    rewrite /map/v3/kela/fi/(.*) /otp/routers/kela/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/kela/sv/ {
-    rewrite /map/v3/kela/sv/(.*) /otp/routers/kela/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/kela/en/ {
-    rewrite /map/v3/kela/en/(.*) /otp/routers/kela/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
-}
-
 location /map/v3-kela/kela/fi/ {
     rewrite /map/v3-kela/kela/fi/(.*) /otp/routers/kela/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-kela-v2:8080;
@@ -336,16 +309,6 @@ location /routing/v2/routers/waltti-alt {
 location /routing/v2/routers/varely {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080/;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    # proxy_set_header   X-Forwarded-Host $host;
-    proxy_read_timeout 11500ms;
-}
-
-location /routing/v2/routers/kela {
-    rewrite /routing/v2/(.*) /otp/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080/;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Now that the new endpoints are in production, we can remove the old ones.