### PR TITLE
Try caching any to fix issues with 404 being returned indefinetly

### DIFF
--- a/external.conf
+++ b/external.conf
@@ -376,7 +376,7 @@ location = /out/tampere-api.giravolta.io/api-opendata/gbfs/2_3/gbfs {
   proxy_pass  https://api.giravolta.io/api-opendata/gbfs/2_3/gbfs;
   include allowed-ips.conf;
   proxy_cache ext_cache;
-  proxy_cache_valid 200 302 30s;
+  proxy_cache_valid any 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;
   proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
@@ -394,7 +394,7 @@ location /out/tampere-api.giravolta.io/ {
   proxy_pass  https://api.giravolta.io/;
   include allowed-ips.conf;
   proxy_cache ext_cache;
-  proxy_cache_valid 200 302 30s;
+  proxy_cache_valid any 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;
   proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
@@ -413,7 +413,7 @@ location = /out/vantaa-api.giravolta.io/api-opendata/gbfs/2_3/gbfs {
   proxy_pass  https://api.giravolta.io/api-opendata/gbfs/2_3/gbfs;
   include allowed-ips.conf;
   proxy_cache ext_cache;
-  proxy_cache_valid 200 302 30s;
+  proxy_cache_valid any 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;
   proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
@@ -431,7 +431,7 @@ location /out/vantaa-api.giravolta.io/ {
   proxy_pass  https://api.giravolta.io/;
   include allowed-ips.conf;
   proxy_cache ext_cache;
-  proxy_cache_valid 200 302 30s;
+  proxy_cache_valid any 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;
   proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
@@ -446,7 +446,7 @@ location /out/rata.digitraffic.fi/ {
   proxy_pass    https://rata.digitraffic.fi/;
   include allowed-ips.conf;
   proxy_cache   ext_cache;
-  proxy_cache_valid 200 30s;
+  proxy_cache_valid any 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;
   proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;


### PR DESCRIPTION
We have issues that the proxy returns 404 for some endpoints occasionally until the proxy is restarted.