### PR TITLE
DT-6374 patch tilejson files to contain proper tiles URL

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -69,31 +69,13 @@ location ~ ^/map/v3/hsl/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3/hsl/fi/ {
-    rewrite /map/v3/hsl/fi/(.*) /otp/routers/hsl/vectorTiles/$1  break;
+location /map/v3/hsl/ {
+    rewrite /map/v3/hsl/([^\/]*)/(.*) /otp/routers/hsl/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/hsl/sv/ {
-    rewrite /map/v3/hsl/sv/(.*) /otp/routers/hsl/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/hsl/en/ {
-    rewrite /map/v3/hsl/en/(.*) /otp/routers/hsl/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-hsl-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location /map/v3/hsl/ticket-sales-map/ {
@@ -115,31 +97,13 @@ location ~ ^/map/v3/waltti/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3/waltti/fi/ {
-    rewrite /map/v3/waltti/fi/(.*) /otp/routers/waltti/vectorTiles/$1  break;
+location /map/v3/waltti/ {
+    rewrite /map/v3/waltti/([^\/]*)/(.*) /otp/routers/waltti/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/waltti/sv/ {
-    rewrite /map/v3/waltti/sv/(.*) /otp/routers/waltti/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/waltti/en/ {
-    rewrite /map/v3/waltti/en/(.*) /otp/routers/waltti/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-waltti-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location ~ ^/map/v3/finland/(.*)/tilejson.json$ {
@@ -153,31 +117,13 @@ location ~ ^/map/v3/finland/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3/finland/fi/ {
-    rewrite /map/v3/finland/fi/(.*) /otp/routers/finland/vectorTiles/$1  break;
+location /map/v3/finland/ {
+    rewrite /map/v3/finland/([^\/]*)/(.*) /otp/routers/finland/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-finland-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/finland/sv/ {
-    rewrite /map/v3/finland/sv/(.*) /otp/routers/finland/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/finland/en/ {
-    rewrite /map/v3/finland/en/(.*) /otp/routers/finland/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-finland-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location ~ ^/map/v3/waltti-alt/(.*)/tilejson.json$ {
@@ -191,31 +137,13 @@ location ~ ^/map/v3/waltti-alt/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3/waltti-alt/fi/ {
-    rewrite /map/v3/waltti-alt/fi/(.*) /otp/routers/waltti-alt/vectorTiles/$1  break;
+location /map/v3/waltti-alt/ {
+    rewrite /map/v3/waltti-alt/([^\/]*)/(.*) /otp/routers/waltti-alt/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/waltti-alt/sv/ {
-    rewrite /map/v3/waltti-alt/sv/(.*) /otp/routers/waltti-alt/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/waltti-alt/en/ {
-    rewrite /map/v3/waltti-alt/en/(.*) /otp/routers/waltti-alt/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location ~ ^/map/v3/varely/(.*)/tilejson.json$ {
@@ -229,31 +157,13 @@ location ~ ^/map/v3/varely/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3/varely/fi/ {
-    rewrite /map/v3/varely/fi/(.*) /otp/routers/varely/vectorTiles/$1  break;
+location /map/v3/varely/ {
+    rewrite /map/v3/varely/([^\/]*)/(.*) /otp/routers/varely/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-varely-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3/varely/sv/ {
-    rewrite /map/v3/varely/sv/(.*) /otp/routers/varely/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-varely-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3/varely/en/ {
-    rewrite /map/v3/varely/en/(.*) /otp/routers/varely/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-varely-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location ~ ^/map/v3-kela/kela/(.*)/tilejson.json$ {
@@ -267,31 +177,13 @@ location ~ ^/map/v3-kela/kela/(.*)/tilejson.json$ {
     sub_filter_types   *;
 }
 
-location /map/v3-kela/kela/fi/ {
-    rewrite /map/v3-kela/kela/fi/(.*) /otp/routers/kela/vectorTiles/$1  break;
+location /map/v3-kela/kela/ {
+    rewrite /map/v3-kela/kela/([^\/]*)/(.*) /otp/routers/kela/vectorTiles/$2  break;
     proxy_pass         http://opentripplanner-kela-v2:8080;
     proxy_redirect     off;
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "fi";
-}
-
-location /map/v3-kela/kela/sv/ {
-    rewrite /map/v3-kela/kela/sv/(.*) /otp/routers/kela/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "sv";
-}
-
-location /map/v3-kela/kela/en/ {
-    rewrite /map/v3-kela/kela/en/(.*) /otp/routers/kela/vectorTiles/$1  break;
-    proxy_pass         http://opentripplanner-kela-v2:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header   Accept-Language "en";
+    proxy_set_header   Accept-Language $1;
 }
 
 location /graphiql/ {

--- a/common.conf
+++ b/common.conf
@@ -44,6 +44,7 @@ location /map/v2/ {
 }
 
 location /map/v3/ {
+    # TODO use /map/v3/
     rewrite /map/v3/(.*) /map/v2/$1  break;
     proxy_pass         http://hsl-map-server:8080;
     proxy_cache        tiles;
@@ -79,6 +80,7 @@ location /map/v3/hsl/ {
 }
 
 location /map/v3/hsl/ticket-sales-map/ {
+    #TODO use v3 or remove this location
     rewrite /map/v3/hsl/ticket-sales-map/(.*) /map/v2/hsl-ticket-sales-map/$1  break;
     proxy_pass         http://hsl-map-server:8080;
     proxy_redirect     off;

--- a/common.conf
+++ b/common.conf
@@ -58,6 +58,17 @@ location /map/v3/ {
     add_header         X-Cache-Status $upstream_cache_status;
 }
 
+location ~ ^/map/v3/hsl/(.*)/tilejson.json$ {
+    rewrite /map/v3/hsl/([^\/]*)/(.*) /otp/routers/hsl/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/hsl/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3/hsl/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
+}
+
 location /map/v3/hsl/fi/ {
     rewrite /map/v3/hsl/fi/(.*) /otp/routers/hsl/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080;
@@ -93,6 +104,17 @@ location /map/v3/hsl/ticket-sales-map/ {
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
+location ~ ^/map/v3/waltti/(.*)/tilejson.json$ {
+    rewrite /map/v3/waltti/([^\/]*)/(.*) /otp/routers/waltti/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/waltti/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3/waltti/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
+}
+
 location /map/v3/waltti/fi/ {
     rewrite /map/v3/waltti/fi/(.*) /otp/routers/waltti/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;
@@ -118,6 +140,17 @@ location /map/v3/waltti/en/ {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   Accept-Language "en";
+}
+
+location ~ ^/map/v3/finland/(.*)/tilejson.json$ {
+    rewrite /map/v3/finland/([^\/]*)/(.*) /otp/routers/finland/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-finland-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/finland/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3/finland/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
 }
 
 location /map/v3/finland/fi/ {
@@ -147,6 +180,17 @@ location /map/v3/finland/en/ {
     proxy_set_header   Accept-Language "en";
 }
 
+location ~ ^/map/v3/waltti-alt/(.*)/tilejson.json$ {
+    rewrite /map/v3/waltti-alt/([^\/]*)/(.*) /otp/routers/waltti-alt/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/waltti-alt/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3/waltti-alt/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
+}
+
 location /map/v3/waltti-alt/fi/ {
     rewrite /map/v3/waltti-alt/fi/(.*) /otp/routers/waltti-alt/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080;
@@ -174,6 +218,17 @@ location /map/v3/waltti-alt/en/ {
     proxy_set_header   Accept-Language "en";
 }
 
+location ~ ^/map/v3/varely/(.*)/tilejson.json$ {
+    rewrite /map/v3/varely/([^\/]*)/(.*) /otp/routers/varely/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-varely-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/varely/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3/varely/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
+}
+
 location /map/v3/varely/fi/ {
     rewrite /map/v3/varely/fi/(.*) /otp/routers/varely/vectorTiles/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080;
@@ -199,6 +254,17 @@ location /map/v3/varely/en/ {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header   Accept-Language "en";
+}
+
+location ~ ^/map/v3-kela/kela/(.*)/tilejson.json$ {
+    rewrite /map/v3-kela/kela/([^\/]*)/(.*) /otp/routers/kela/vectorTiles/$2 break;
+    proxy_pass         http://opentripplanner-kela-v2:8080;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header         Cache-Control "no-cache, no-store, must-revalidate";
+    sub_filter         "https://$host/otp/routers/kela/vectorTiles/$vector_layers/{z}/{x}/{y}.pbf" "CDN_BASE_URL/map/v3-kela/kela/$map_lang/$vector_layers/{z}/{x}/{y}.pbf$subscription_key_param";
+    sub_filter_types   *;
 }
 
 location /map/v3-kela/kela/fi/ {

--- a/external.conf
+++ b/external.conf
@@ -10,23 +10,11 @@ location /out/helsinki-fi.smoove.pro/ {
   proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
 }
 
-#turku smoove citybike api (http://data.foli.fi/citybike/smoove)
+#turku smoove realtime api (http://data.foli.fi/gtfs-rt/reittiopas)
 location /out/data.foli.fi/ {
   proxy_pass  http://data.foli.fi/;
   include allowed-ips.conf;
   proxy_cache ext_cache;
-  proxy_cache_valid 200 30s;
-  proxy_cache_lock on;
-  add_header X-Proxy-Cache $upstream_cache_status;
-  proxy_ignore_headers X-Accel-Expires Expires Cache-Control Set-Cookie;
-  proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-}
-
-#oulu realtime api (http://92.62.36.215/RTIX/trip-update)
-location /out/92.62.36.215/ {
-  proxy_pass    http://92.62.36.215/;
-  include allowed-ips.conf;
-  proxy_cache   ext_cache;
   proxy_cache_valid 200 30s;
   proxy_cache_lock on;
   add_header X-Proxy-Cache $upstream_cache_status;

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,6 +60,24 @@ http {
   # to get rid of a warning about server_names_hash building
   server_names_hash_bucket_size  128;
 
+  # Following maps are needed for patching tilejson tiles urls in map layers
+  map $args $digitransit_subscription_key {
+    "~(^|&)digitransit-subscription-key=(?<temp>[^&]+)" $temp;
+  }
+
+  map $digitransit_subscription_key $subscription_key_param {
+    default ?digitransit-subscription-key=$digitransit_subscription_key;
+    "" "";
+  }
+
+  map $request_uri $map_lang {
+    ~^/map/v3/(.*)/(.*)/(.*)/(.*) $2;
+  }
+
+  map $request_uri $vector_layers {
+    ~^/map/v3/(.*)/(.*)/(.*)/(.*) $3;
+  }
+
   server {
     listen 8080 default_server;
     include external.conf;

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,7 @@
 #!/bin/ash
 
 set -e
-#workaround for azure DNS issue
-if [ -n "$MESOS_CONTAINER_NAME"  ]; then 
-  echo "search marathon.l4lb.thisdcos.directory" >> /etc/resolv.conf;
-fi
+
 sed -i "s/VILKKU_BASIC_AUTH/${VILKKU_BASIC_AUTH}/" /etc/nginx/external.conf
 sed -i "s/JOJO_BASIC_AUTH/${JOJO_BASIC_AUTH}/" /etc/nginx/external.conf
 sed -i "s/LAPPEENRANTA_BASIC_AUTH/${LAPPEENRANTA_BASIC_AUTH}/" /etc/nginx/external.conf

--- a/run.sh
+++ b/run.sh
@@ -30,6 +30,7 @@ sed -i "s/PORI_RT_BASIC_AUTH/${PORI_RT_BASIC_AUTH}/" /etc/nginx/external.conf
 sed -i "s/MH_BASIC_AUTH/${MH_BASIC_AUTH}/" /etc/nginx/external.conf
 sed -i "s/NYSSE_BASIC_AUTH/${NYSSE_BASIC_AUTH}/" /etc/nginx/external.conf
 sed -i "s/WALTTI_TEST_STATIC_BASIC_AUTH/${WALTTI_TEST_STATIC_BASIC_AUTH}/" /etc/nginx/external.conf
+sed -i "s#CDN_BASE_URL#${CDN_BASE_URL}#" /etc/nginx/common.conf
 
 #set basic auth
 htpasswd -c -B -b .htpasswd $WALTTI_TEST_CREDENTIALS_USER $WALTTI_TEST_CREDENTIALS_PASS &>/dev/null

--- a/test.js
+++ b/test.js
@@ -315,8 +315,7 @@ describe('otp debug', function() {
 describe('ext-proxy', function() {
   this.timeout(5000);
   testCaching(null,'/out/helsinki-fi.smoove.pro/api-public/stations',false);
-  testCaching(null,'/out/data.foli.fi/citybike/smoove',false);
-  testCaching(null,'/out/92.62.36.215/RTIX/trip-updates',false);
+  testCaching(null,'/out/data.foli.fi/gtfs-rt/reittiopas',false);
   testCaching(null,'/out/stables.donkey.bike/api/public/gbfs/2/donkey_lappeenranta/en/station_status.json',false);
 });
 

--- a/test.js
+++ b/test.js
@@ -156,6 +156,7 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/map/v3/hsl/ticket-sales-map/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl/en/rental-stations/','opentripplanner-hsl-v2:8080');
   testProxying('api.digitransit.fi','/map/v3/waltti/en/rental-stations/','opentripplanner-waltti-v2:8080');
+  testProxying('api.digitransit.fi','/map/v3/hsl/fi/stops,stations/tilejson.json','opentripplanner-hsl-v2:8080');
   testProxying('api.digitransit.fi','/map/v3/finland/en/rental-stations/','opentripplanner-finland-v2:8080');
   testProxying('api.digitransit.fi','/map/v3/varely/en/stops,stations/','opentripplanner-varely-v2:8080');
   testProxying('api.digitransit.fi','/map/v3/waltti-alt/en/rental-stations/','opentripplanner-waltti-alt-v2:8080');

--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,7 @@ CONTAINER_ID=$(docker run -d -p 9000:8080 $ADDHOSTS -e VILKKU_BASIC_AUTH="\"test
   -e RAUMA_RT_BASIC_AUTH="\"test\"" -e RAUMA_STATIC_BASIC_AUTH="\"test\"" \
   -e PORI_RT_BASIC_AUTH="\"test\"" -e MH_BASIC_AUTH="\"test\"" -e RAASEPORI_RT_BASIC_AUTH="\"test\"" \
   -e WALTTI_TEST_CREDENTIALS_USER="test" -e WALTTI_TEST_CREDENTIALS_PASS="test" -e WALTTI_TEST_STATIC_BASIC_AUTH="\"test\"" \
+  -e CDN_BASE_URL="test" \
   hsldevcom/digitransit-proxy:integrationtest)
 
 curl -v http://127.0.0.1:9000


### PR DESCRIPTION
* Removed some legacy stuff that is not needed anymore
* Merged vectortile locations which set different language headers into one per router
* Added separate location for tilejson files which patch the proper CDN url structure into tiles url and sets cache times as 0 (this is so someone's subscription keys don't get cached and reused by others)