### PR TITLE
DT-6436 Add new GTFS graphql endpoint, health check endpoint and limit usage of other routing APIs

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -246,6 +246,15 @@ location /routing/v2/routers/finland {
     proxy_read_timeout 29500ms;
 }
 
+location = /routing/v2/finland/gtfs/v1 {
+    rewrite /routing/v2/finland/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 29500ms;
+}
+
 location /routing/v2/routers/waltti {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080/;
@@ -253,6 +262,15 @@ location /routing/v2/routers/waltti {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     # proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/waltti/gtfs/v1 {
+    rewrite /routing/v2/waltti/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
 }
 
@@ -266,6 +284,15 @@ location /routing/v2/routers/waltti-alt {
     proxy_read_timeout 11500ms;
 }
 
+location = /routing/v2/waltti-alt/gtfs/v1 {
+    rewrite /routing/v2/waltti-alt/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 11500ms;
+}
+
 location /routing/v2/routers/varely {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080/;
@@ -273,6 +300,15 @@ location /routing/v2/routers/varely {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     # proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/varely/gtfs/v1 {
+    rewrite /routing/v2/varely/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-varely-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
 }
 
@@ -286,6 +322,15 @@ location /routing/v2-kela/routers/kela {
     proxy_read_timeout 29500ms;
 }
 
+location = /routing/v2-kela/kela/gtfs/v1 {
+    rewrite /routing/v2-kela/kela/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-kela-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 29500ms;
+}
+
 location /routing/v2/routers/hsl {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080/;
@@ -293,6 +338,15 @@ location /routing/v2/routers/hsl {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     # proxy_set_header   X-Forwarded-Host $host;
+    proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/hsl/gtfs/v1 {
+    rewrite /routing/v2/hsl/(.*) /otp/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
 }
 

--- a/common.conf
+++ b/common.conf
@@ -255,6 +255,14 @@ location = /routing/v2/finland/gtfs/v1 {
     proxy_read_timeout 29500ms;
 }
 
+location = /routing/v2/finland/health {
+    rewrite /routing/v2/finland/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-finland-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
 location = /routing/v2/routers/waltti/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080/;
@@ -272,6 +280,14 @@ location = /routing/v2/waltti/gtfs/v1 {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/waltti/health {
+    rewrite /routing/v2/waltti/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-waltti-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
 location = /routing/v2/routers/waltti-alt/index/graphql {
@@ -293,6 +309,14 @@ location = /routing/v2/waltti-alt/gtfs/v1 {
     proxy_read_timeout 11500ms;
 }
 
+location = /routing/v2/waltti-alt/health {
+    rewrite /routing/v2/waltti-alt/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-waltti-alt-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
 location = /routing/v2/routers/varely/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080/;
@@ -310,6 +334,14 @@ location = /routing/v2/varely/gtfs/v1 {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/varely/health {
+    rewrite /routing/v2/varely/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-varely-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
 location = /routing/v2-kela/routers/kela/index/graphql {
@@ -331,6 +363,14 @@ location = /routing/v2-kela/kela/gtfs/v1 {
     proxy_read_timeout 29500ms;
 }
 
+location = /routing/v2-kela/kela/health {
+    rewrite /routing/v2-kela/kela/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-kela-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
 location = /routing/v2/routers/hsl/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080/;
@@ -348,6 +388,14 @@ location = /routing/v2/hsl/gtfs/v1 {
     proxy_set_header   X-Real-IP $remote_addr;
     proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_read_timeout 11500ms;
+}
+
+location = /routing/v2/hsl/health {
+    rewrite /routing/v2/hsl/(.*) /otp/actuators/$1  break;
+    proxy_pass         http://opentripplanner-hsl-v2:8080/;
+    proxy_redirect     off;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
 location /routing-data/v2/hsl {

--- a/common.conf
+++ b/common.conf
@@ -236,7 +236,7 @@ location /routing/v1/routers/waltti/profile {
     deny all;
 }
 
-location /routing/v2/routers/finland {
+location = /routing/v2/routers/finland/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-finland-v2:8080/;
     proxy_redirect     off;
@@ -255,7 +255,7 @@ location = /routing/v2/finland/gtfs/v1 {
     proxy_read_timeout 29500ms;
 }
 
-location /routing/v2/routers/waltti {
+location = /routing/v2/routers/waltti/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-waltti-v2:8080/;
     proxy_redirect     off;
@@ -274,7 +274,7 @@ location = /routing/v2/waltti/gtfs/v1 {
     proxy_read_timeout 11500ms;
 }
 
-location /routing/v2/routers/waltti-alt {
+location = /routing/v2/routers/waltti-alt/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-waltti-alt-v2:8080/;
     proxy_redirect     off;
@@ -293,7 +293,7 @@ location = /routing/v2/waltti-alt/gtfs/v1 {
     proxy_read_timeout 11500ms;
 }
 
-location /routing/v2/routers/varely {
+location = /routing/v2/routers/varely/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-varely-v2:8080/;
     proxy_redirect     off;
@@ -312,7 +312,7 @@ location = /routing/v2/varely/gtfs/v1 {
     proxy_read_timeout 11500ms;
 }
 
-location /routing/v2-kela/routers/kela {
+location = /routing/v2-kela/routers/kela/index/graphql {
     rewrite /routing/v2-kela/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-kela-v2:8080/;
     proxy_redirect     off;
@@ -331,7 +331,7 @@ location = /routing/v2-kela/kela/gtfs/v1 {
     proxy_read_timeout 29500ms;
 }
 
-location /routing/v2/routers/hsl {
+location = /routing/v2/routers/hsl/index/graphql {
     rewrite /routing/v2/(.*) /otp/$1  break;
     proxy_pass         http://opentripplanner-hsl-v2:8080/;
     proxy_redirect     off;

--- a/test.js
+++ b/test.js
@@ -173,7 +173,7 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl/ticket-sales-map/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3-kela/kela/en/rental-stations/','opentripplanner-kela-v2:8080');
-  testProxying('dev-api.digitransit.fi','/routing/v2-kela/routers/kela','opentripplanner-kela-v2:8080');
+  testProxying('dev-api.digitransit.fi','/routing/v2-kela/routers/kela/index/graphql','opentripplanner-kela-v2:8080');
   testProxying('api.digitransit.fi','/ui/v3/matka/sw.js','digitransit-ui-matka-v3:8080');
   testProxying('api.digitransit.fi','/ui/v3/hsl/sw.js','digitransit-ui-hsl-v3:8080');
   testProxying('api.digitransit.fi','/ui/v3/waltti/sw.js','digitransit-ui-waltti-v3:8080');

--- a/test.js
+++ b/test.js
@@ -157,6 +157,7 @@ describe('api.digitransit.fi', function() {
   v2routers.forEach(function(router) {
     testProxying('api.digitransit.fi',`/routing/v2/routers/${router}/index/graphql`, `opentripplanner-${router}-v2:8080`);
     testProxying('api.digitransit.fi',`/routing/v2/${router}/gtfs/v1`, `opentripplanner-${router}-v2:8080`);
+    testProxying('api.digitransit.fi',`/routing/v2/${router}/health`, `opentripplanner-${router}-v2:8080`);
     testResponseHeader('api.digitransit.fi',`/routing-data/v3/${router}/router-config.json`, 'access-control-allow-origin', '*');
     testProxying('api.digitransit.fi',`/routing-data/v3/${router}/router-config.json`,`opentripplanner-data-server-${router}-v3:8080`);
     testProxying('api.digitransit.fi',`/map/v3/${router}/en/rental-stations/`, `opentripplanner-${router}-v2:8080`);

--- a/test.js
+++ b/test.js
@@ -144,6 +144,24 @@ describe('api.digitransit.fi', function() {
     });
   });
 
+  const v1routers = ['finland', 'hsl', 'waltti'];
+
+  v1routers.forEach(function(router) {
+    testProxying('api.digitransit.fi',`/routing/v1/routers/${router}/index/graphql`, `opentripplanner-${router}:8080`);
+    testResponseHeader('api.digitransit.fi',`/routing-data/v2/${router}/router-config.json`, 'access-control-allow-origin', '*');
+    testProxying('api.digitransit.fi',`/routing-data/v2/${router}/router-config.json`,`opentripplanner-data-server-${router}:8080`);
+  });
+
+  const v2routers = ['finland', 'hsl', 'waltti', 'waltti-alt', 'varely'];
+
+  v2routers.forEach(function(router) {
+    testProxying('api.digitransit.fi',`/routing/v2/routers/${router}/index/graphql`, `opentripplanner-${router}-v2:8080`);
+    testProxying('api.digitransit.fi',`/routing/v2/${router}/gtfs/v1`, `opentripplanner-${router}-v2:8080`);
+    testResponseHeader('api.digitransit.fi',`/routing-data/v3/${router}/router-config.json`, 'access-control-allow-origin', '*');
+    testProxying('api.digitransit.fi',`/routing-data/v3/${router}/router-config.json`,`opentripplanner-data-server-${router}-v3:8080`);
+    testProxying('api.digitransit.fi',`/map/v3/${router}/en/rental-stations/`, `opentripplanner-${router}-v2:8080`);
+  });
+
   testProxying('api.digitransit.fi','/geocoding/v1/','pelias-api:8080');
   testCaching('api.digitransit.fi','/geocoding/v1/search?digitransit-subscription-key=1234567890&text=porin%20tori', true);
   testCaching('api.digitransit.fi', '/geocoding/v1/reverse?digitransit-subscription-key=1234567890&point.lat=60.199284&point.lon=24.940540&size=1', true)
@@ -154,35 +172,8 @@ describe('api.digitransit.fi', function() {
   testProxying('api.digitransit.fi','/map/v2/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl/ticket-sales-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/hsl/en/rental-stations/','opentripplanner-hsl-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/waltti/en/rental-stations/','opentripplanner-waltti-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/hsl/fi/stops,stations/tilejson.json','opentripplanner-hsl-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/finland/en/rental-stations/','opentripplanner-finland-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/varely/en/stops,stations/','opentripplanner-varely-v2:8080');
-  testProxying('api.digitransit.fi','/map/v3/waltti-alt/en/rental-stations/','opentripplanner-waltti-alt-v2:8080');
   testProxying('api.digitransit.fi','/map/v3-kela/kela/en/rental-stations/','opentripplanner-kela-v2:8080');
-  testProxying('api.digitransit.fi','/routing/v1/routers/finland','opentripplanner-finland:8080');
-  testProxying('api.digitransit.fi','/routing/v1/routers/hsl','opentripplanner-hsl:8080');
-  testProxying('api.digitransit.fi','/routing/v1/routers/waltti','opentripplanner-waltti:8080');
-  testProxying('dev-api.digitransit.fi','/routing/v2/routers/finland','opentripplanner-finland-v2:8080');
-  testProxying('dev-api.digitransit.fi','/routing/v2/routers/hsl','opentripplanner-hsl-v2:8080');
-  testProxying('dev-api.digitransit.fi','/routing/v2/routers/waltti','opentripplanner-waltti-v2:8080');
-  testProxying('dev-api.digitransit.fi','/routing/v2/routers/waltti-alt','opentripplanner-waltti-alt-v2:8080');
   testProxying('dev-api.digitransit.fi','/routing/v2-kela/routers/kela','opentripplanner-kela-v2:8080');
-  testProxying('api.digitransit.fi','/routing-data/v2/hsl/router-hsl.zip','opentripplanner-data-server-hsl:8080');
-  testResponseHeader('api.digitransit.fi','/routing-data/v2/hsl/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('api.digitransit.fi','/routing-data/v2/waltti/router-waltti.zip','opentripplanner-data-server-waltti:8080');
-  testResponseHeader('api.digitransit.fi','/routing-data/v2/waltti/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('api.digitransit.fi','/routing-data/v2/finland/router-finland.zip','opentripplanner-data-server-finland:8080');
-  testResponseHeader('api.digitransit.fi','/routing-data/v2/finland/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('dev-api.digitransit.fi','/routing-data/v3/hsl/router-hsl.zip','opentripplanner-data-server-hsl-v3:8080');
-  testResponseHeader('dev-api.digitransit.fi','/routing-data/v3/hsl/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('dev-api.digitransit.fi','/routing-data/v3/waltti/router-waltti.zip','opentripplanner-data-server-waltti-v3:8080');
-  testResponseHeader('dev-api.digitransit.fi','/routing-data/v3/waltti/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('dev-api.digitransit.fi','/routing-data/v3/waltti-alt/router-waltti.zip','opentripplanner-data-server-waltti-alt-v3:8080');
-  testResponseHeader('dev-api.digitransit.fi','/routing-data/v3/waltti-alt/router-config.json', 'access-control-allow-origin', '*');
-  testProxying('dev-api.digitransit.fi','/routing-data/v3/finland/router-finland.zip','opentripplanner-data-server-finland-v3:8080');
-  testResponseHeader('dev-api.digitransit.fi','/routing-data/v3/finland/router-config.json', 'access-control-allow-origin', '*');
   testProxying('api.digitransit.fi','/ui/v3/matka/sw.js','digitransit-ui-matka-v3:8080');
   testProxying('api.digitransit.fi','/ui/v3/hsl/sw.js','digitransit-ui-hsl-v3:8080');
   testProxying('api.digitransit.fi','/ui/v3/waltti/sw.js','digitransit-ui-waltti-v3:8080');


### PR DESCRIPTION
This pr blocks usage of REST and `/routing/v2/routers/waltti/` type healthcheck endpoints, they are replaced by a new health check endpoint `/routing/v2/waltti/health/`.

New GraphQL endpoint is added which follows the structure of `/routing/v2/hsl/gtfs/v1`. It will replace the old one.