### PR TITLE
Clean map v3

### DIFF
--- a/common.conf
+++ b/common.conf
@@ -44,8 +44,7 @@ location /map/v2/ {
 }
 
 location /map/v3/ {
-    # TODO use /map/v3/
-    rewrite /map/v3/(.*) /map/v2/$1  break;
+    rewrite /map/v3/(.*) /map/v3/$1  break;
     proxy_pass         http://hsl-map-server:8080;
     proxy_cache        tiles;
     proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;

--- a/common.conf
+++ b/common.conf
@@ -79,15 +79,6 @@ location /map/v3/hsl/ {
     proxy_set_header   Accept-Language $1;
 }
 
-location /map/v3/hsl/ticket-sales-map/ {
-    #TODO use v3 or remove this location
-    rewrite /map/v3/hsl/ticket-sales-map/(.*) /map/v2/hsl-ticket-sales-map/$1  break;
-    proxy_pass         http://hsl-map-server:8080;
-    proxy_redirect     off;
-    proxy_set_header   X-Real-IP $remote_addr;
-    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
 location ~ ^/map/v3/waltti/(.*)/tilejson.json$ {
     rewrite /map/v3/waltti/([^\/]*)/(.*) /otp/routers/waltti/vectorTiles/$2 break;
     proxy_pass         http://opentripplanner-waltti-v2:8080;

--- a/test.js
+++ b/test.js
@@ -172,7 +172,6 @@ describe('api.digitransit.fi', function() {
   //testCaching('api.digitransit.fi','/realtime/trip-updates/v1/foo', false)
   testProxying('api.digitransit.fi','/map/v2/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3/hsl-map/','hsl-map-server:8080');
-  testProxying('api.digitransit.fi','/map/v3/hsl/ticket-sales-map/','hsl-map-server:8080');
   testProxying('api.digitransit.fi','/map/v3-kela/kela/en/rental-stations/','opentripplanner-kela-v2:8080');
   testProxying('dev-api.digitransit.fi','/routing/v2-kela/routers/kela/index/graphql','opentripplanner-kela-v2:8080');
   testProxying('api.digitransit.fi','/ui/v3/matka/sw.js','digitransit-ui-matka-v3:8080');


### PR DESCRIPTION
*  Remove ticket sales map from v3
* Use map server's v3 endpoints for v3 map, this removes legacy vector tile endpoints from v3