### PR TITLE
DT-6870 - Add more routes for debug UIs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -434,7 +434,7 @@ http {
   }
 
   server {
-    server_name hsl-debug.digitransit.fi;
+    server_name dev-hsl-debug.digitransit.fi hsl-debug.digitransit.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {
@@ -451,7 +451,7 @@ http {
   }
 
   server {
-    server_name waltti-debug.digitransit.fi;
+    server_name dev-waltti-debug.digitransit.fi waltti-debug.digitransit.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {
@@ -468,7 +468,7 @@ http {
   }
 
   server {
-    server_name finland-debug.digitransit.fi;
+    server_name dev-finland-debug.digitransit.fi finland-debug.digitransit.fi;
     listen 8080;
 
     if ($http_x_forwarded_proto != "https") {
@@ -497,6 +497,23 @@ http {
 
     location / {
       proxy_pass         http://opentripplanner-waltti-alt-v2:8080/;
+      include basicsettings.conf;
+    }
+  }
+
+  server {
+    server_name dev-varely-debug.digitransit.fi varely-debug.digitransit.fi;
+    listen 8080;
+
+    if ($http_x_forwarded_proto != "https") {
+      return 301 https://$host$request_uri;
+    }
+
+    # Add HTTP Strict Transport Security for good measure.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+
+    location / {
+      proxy_pass         http://opentripplanner-varely-v2:8080/;
       include basicsettings.conf;
     }
   }

--- a/test.js
+++ b/test.js
@@ -299,9 +299,14 @@ describe('digitransit', function() {
 });
 
 describe('otp debug', function() {
+  testProxying('dev-hsl-debug.digitransit.fi','/','opentripplanner-hsl-v2:8080', true);
+  testProxying('dev-waltti-debug.digitransit.fi','/','opentripplanner-waltti-v2:8080', true);
+  testProxying('dev-finland-debug.digitransit.fi','/','opentripplanner-finland-v2:8080', true);
+  testProxying('dev-varely-debug.digitransit.fi','/','opentripplanner-varely-v2:8080', true);
   testProxying('hsl-debug.digitransit.fi','/','opentripplanner-hsl-v2:8080', true);
   testProxying('waltti-debug.digitransit.fi','/','opentripplanner-waltti-v2:8080', true);
   testProxying('finland-debug.digitransit.fi','/','opentripplanner-finland-v2:8080', true);
+  testProxying('varely-debug.digitransit.fi','/','opentripplanner-varely-v2:8080', true);
   testProxying('waltti-alt-debug.digitransit.fi','/','opentripplanner-waltti-alt-v2:8080', true);
 });
 


### PR DESCRIPTION
Routes added:
- dev-hsl-debug.digitransit.fi -> dev
- dev-waltti-debug.digitransit.fi -> dev
- dev-finland-debug.digitransit.fi -> dev
- dev-varely-debug.digitransit.fi -> dev
- varely-debug.digitransit.fi -> prod

Routes rerouted:
- hsl-debug.digitransit.fi -> prod
- waltti-debug.digitransit.fi -> prod
- finland-debug.digitransit.fi -> prod

Routes not changed:
- waltti-alt-debug.digitransit.fi

Routes **NOT** added:
- kela-debug.digitransit.fi -> prod
- dev-kela-debug.digitransit.fi -> dev